### PR TITLE
build Windows in Release mode

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,7 @@ cd build
 
 cmake -G "NMake Makefiles" ^
       -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D CMAKE_BUILD_TYPE=Release ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - empty_char.patch  # [win and vc==14]
 
 build:
-  number: 1013
+  number: 1014
   skip: True  # [vc<14 and win]
   run_exports:
     # no ABI lab result.  Pinning to major-minor as conda-forge has.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
 
 about:
   home: https://github.com/libkml/libkml
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: 'Reference implementation of OGC KML 2.2'
   description: |


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

xref: https://github.com/conda-forge/gdal-feedstock/pull/508

The default build type for `cmake` is Debug. On Windows, this means linking errors with other packages as Debug and Release compiled libraries cannot be mixed. 

This PR sets the build type to Release on Windows so it is compatible with the rest of the conda forge stack.