### PR TITLE
unvendor gnarly minizip, use minizip-ng 1.2 from conda-forge

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,7 @@
 mkdir build
 cd build
 
-cmake -G "NMake Makefiles" ^
+cmake -G Ninja ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DBUILD_TESTING=ON ^
     -DCMAKE_BUILD_TYPE=Release ^
@@ -16,5 +16,5 @@ if %ERRORLEVEL% neq 0 exit 1
 ctest --progress --output-on-failure
 if %ERRORLEVEL% neq 0 exit 1
 
-nmake install
+cmake --install .
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,13 @@
 @echo on
 
+:: remove all doubt where minizip comes from by removing vendored bits
+rmdir \s \q src\kml\base\contrib\minizip
+
 mkdir build
 cd build
+
+:: We're reusing the variable in CMake, which doesn't like backslashes
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
 
 cmake -G Ninja ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,9 @@
 #! /bin/bash
 set -ex
 
+# remove all doubt where minizip comes from by removing vendored bits
+rm -rf ./src/kml/base/contrib/minizip
+
 mkdir build
 cd build
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,8 @@ if [[ "${build_platform}" == "${target_platform}" ]]; then
     export CMAKE_ARGS="${CMAKE_ARGS} -DBUILD_TESTING=ON"
 fi
 
-cmake ${CMAKE_ARGS} \
+cmake -G Ninja \
+    ${CMAKE_ARGS} \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     ..
 
@@ -17,4 +18,5 @@ cmake --build .
 if [[ "${build_platform}" == "${target_platform}" ]]; then
     DYLD_FALLBACK_LIBRARY_PATH=${PREFIX}/lib ctest --progress --output-on-failure
 fi
-make install -j $CPU_COUNT
+
+cmake --install .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch  # [win]
 
 build:
-  number: 1018
+  number: 1019
   run_exports:
     # no ABI lab result.  Pinning to major-minor as conda-forge has.
     - {{ pin_subpackage('libkml', max_pin='x.x') }}
@@ -33,8 +33,10 @@ requirements:
     - libboost-headers
     - expat
     - uriparser
-    # not compatible with minizip in conda-forge, see GH-2
-    # - minizip 1.*
+    # not compatible with newer minizip in conda-forge, see GH-2
+    # we need to use the static builds, because we cannot have
+    # two different versions of shared minizip in the same env.
+    - minizip-static 1.*
     - zlib
     # only for testing
     - gtest  # [build_platform == target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
     - patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
     # skip a very few failing tests on windows
     - patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch  # [win]
+    # force use of our minizip, even if built statically
+    - patches/0004-ensure-we-pick-up-minizip-correctly.patch
 
 build:
   number: 1019

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ source:
     - patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch  # [win]
     # force use of our minizip, even if built statically
     - patches/0004-ensure-we-pick-up-minizip-correctly.patch
+    # switch over from vendored API to newer minizip, for longer explanation see:
+    # https://github.com/conda-forge/libkml-feedstock/issues/2#issuecomment-1746247426
+    - patches/0005-patch-things-up-for-use-with-newer-minizip.patch
 
 build:
   number: 1019

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,13 @@ test:
     - if not exist %LIBRARY_LIB%\kml{{ each_lib }}.lib exit 1   # [win]
     {% endfor %}
 
+    # ensure we're not shipping minizip, see GH-2;
+    # we cannot do the same to test for absence of uriparser, because
+    # it's a runtime dependence and thus present in the environment
+    - test ! -f $PREFIX/lib/libminizip.so           # [linux]
+    - test ! -f $PREFIX/lib/libminizip.dylib        # [osx]
+    - if exist %LIBRARY_LIB%\minizip.lib exit 1     # [win]
+
 about:
   home: https://github.com/libkml/libkml
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
     # https://github.com/conda-forge/libkml-feedstock/issues/2#issuecomment-1746247426
     - patches/0005-patch-things-up-for-use-with-newer-minizip.patch
     - patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
+    - patches/0007-copy-over-a-define-necessary-for-libmkl-s-zip-handli.patch
 
 build:
   number: 1019

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ source:
     # switch over from vendored API to newer minizip, for longer explanation see:
     # https://github.com/conda-forge/libkml-feedstock/issues/2#issuecomment-1746247426
     - patches/0005-patch-things-up-for-use-with-newer-minizip.patch
+    - patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
 
 build:
   number: 1019

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,9 +55,18 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libkmlbase.so.1  # [linux]
-    - test -f $PREFIX/lib/libkmlbase.dylib  # [osx]
-    - if not exist %LIBRARY_LIB%\\kmlbase.lib exit 1  # [win]
+    {% set libs = ["base", "convenience", "dom", "engine", "regionator", "xsd"] %}
+    {% for each_lib in libs %}
+    # presence of shared libs (only unix)
+    - test -f $PREFIX/lib/libkml{{ each_lib }}.so               # [linux]
+    - test -f $PREFIX/lib/libkml{{ each_lib }}.dylib            # [osx]
+
+    # absence of static libraries (unix)
+    - test ! -f $PREFIX/lib/libkml{{ each_lib }}.a              # [unix]
+
+    # presence of static libs on windows
+    - if not exist %LIBRARY_LIB%\kml{{ each_lib }}.lib exit 1   # [win]
+    {% endfor %}
 
 about:
   home: https://github.com/libkml/libkml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make  # [unix]
+    - ninja
   host:
     - libboost-headers
     - expat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ source:
     - patches/0005-patch-things-up-for-use-with-newer-minizip.patch
     - patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
     - patches/0007-copy-over-a-define-necessary-for-libmkl-s-zip-handli.patch
+    # we don't have to fail on files produced by less ancient zip versions anymore
+    - patches/0008-remove-expected-failure-for-handling-newer-zips.patch
 
 build:
   number: 1019

--- a/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
+++ b/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
@@ -1,7 +1,7 @@
 From 808662da0c17e6648081b46ed16b9efa44ff7fff Mon Sep 17 00:00:00 2001
 From: Alexander Bobkov <alexander.e.bobkov@gmail.com>
 Date: Mon, 13 Jun 2016 17:58:57 +0300
-Subject: [PATCH 1/4] Visual Studio 2015 build fix
+Subject: [PATCH 1/5] Visual Studio 2015 build fix
 
 ---
  src/kml/base/file_win32.cc | 3 ++-

--- a/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
+++ b/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
@@ -1,7 +1,7 @@
 From 808662da0c17e6648081b46ed16b9efa44ff7fff Mon Sep 17 00:00:00 2001
 From: Alexander Bobkov <alexander.e.bobkov@gmail.com>
 Date: Mon, 13 Jun 2016 17:58:57 +0300
-Subject: [PATCH 1/7] Visual Studio 2015 build fix
+Subject: [PATCH 1/8] Visual Studio 2015 build fix
 
 ---
  src/kml/base/file_win32.cc | 3 ++-

--- a/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
+++ b/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
@@ -1,7 +1,7 @@
 From 808662da0c17e6648081b46ed16b9efa44ff7fff Mon Sep 17 00:00:00 2001
 From: Alexander Bobkov <alexander.e.bobkov@gmail.com>
 Date: Mon, 13 Jun 2016 17:58:57 +0300
-Subject: [PATCH 1/6] Visual Studio 2015 build fix
+Subject: [PATCH 1/7] Visual Studio 2015 build fix
 
 ---
  src/kml/base/file_win32.cc | 3 ++-

--- a/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
+++ b/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
@@ -1,7 +1,7 @@
 From 808662da0c17e6648081b46ed16b9efa44ff7fff Mon Sep 17 00:00:00 2001
 From: Alexander Bobkov <alexander.e.bobkov@gmail.com>
 Date: Mon, 13 Jun 2016 17:58:57 +0300
-Subject: [PATCH 1/3] Visual Studio 2015 build fix
+Subject: [PATCH 1/4] Visual Studio 2015 build fix
 
 ---
  src/kml/base/file_win32.cc | 3 ++-

--- a/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
+++ b/recipe/patches/0001-Visual-Studio-2015-build-fix.patch
@@ -1,7 +1,7 @@
 From 808662da0c17e6648081b46ed16b9efa44ff7fff Mon Sep 17 00:00:00 2001
 From: Alexander Bobkov <alexander.e.bobkov@gmail.com>
 Date: Mon, 13 Jun 2016 17:58:57 +0300
-Subject: [PATCH 1/5] Visual Studio 2015 build fix
+Subject: [PATCH 1/6] Visual Studio 2015 build fix
 
 ---
  src/kml/base/file_win32.cc | 3 ++-

--- a/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
+++ b/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
@@ -1,7 +1,7 @@
 From 5bd81aa4c92e04498c2815235231eb3ec0f57149 Mon Sep 17 00:00:00 2001
 From: Diego Sogari <diego.sogari@gmail.com>
 Date: Sun, 3 Jul 2016 07:30:25 -0300
-Subject: [PATCH 2/3] compile and test libkml on MinGW from the MSYS2 project:
+Subject: [PATCH 2/4] compile and test libkml on MinGW from the MSYS2 project:
 
  - fix initialization of static variable in Testb2a_hex from string_util_test.cc
  - provide setenv function in google_maps_data_test.cc

--- a/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
+++ b/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
@@ -1,7 +1,7 @@
 From 5bd81aa4c92e04498c2815235231eb3ec0f57149 Mon Sep 17 00:00:00 2001
 From: Diego Sogari <diego.sogari@gmail.com>
 Date: Sun, 3 Jul 2016 07:30:25 -0300
-Subject: [PATCH 2/7] compile and test libkml on MinGW from the MSYS2 project:
+Subject: [PATCH 2/8] compile and test libkml on MinGW from the MSYS2 project:
 
  - fix initialization of static variable in Testb2a_hex from string_util_test.cc
  - provide setenv function in google_maps_data_test.cc

--- a/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
+++ b/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
@@ -1,7 +1,7 @@
 From 5bd81aa4c92e04498c2815235231eb3ec0f57149 Mon Sep 17 00:00:00 2001
 From: Diego Sogari <diego.sogari@gmail.com>
 Date: Sun, 3 Jul 2016 07:30:25 -0300
-Subject: [PATCH 2/5] compile and test libkml on MinGW from the MSYS2 project:
+Subject: [PATCH 2/6] compile and test libkml on MinGW from the MSYS2 project:
 
  - fix initialization of static variable in Testb2a_hex from string_util_test.cc
  - provide setenv function in google_maps_data_test.cc

--- a/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
+++ b/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
@@ -1,7 +1,7 @@
 From 5bd81aa4c92e04498c2815235231eb3ec0f57149 Mon Sep 17 00:00:00 2001
 From: Diego Sogari <diego.sogari@gmail.com>
 Date: Sun, 3 Jul 2016 07:30:25 -0300
-Subject: [PATCH 2/4] compile and test libkml on MinGW from the MSYS2 project:
+Subject: [PATCH 2/5] compile and test libkml on MinGW from the MSYS2 project:
 
  - fix initialization of static variable in Testb2a_hex from string_util_test.cc
  - provide setenv function in google_maps_data_test.cc

--- a/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
+++ b/recipe/patches/0002-compile-and-test-libkml-on-MinGW-from-the-MSYS2-proj.patch
@@ -1,7 +1,7 @@
 From 5bd81aa4c92e04498c2815235231eb3ec0f57149 Mon Sep 17 00:00:00 2001
 From: Diego Sogari <diego.sogari@gmail.com>
 Date: Sun, 3 Jul 2016 07:30:25 -0300
-Subject: [PATCH 2/6] compile and test libkml on MinGW from the MSYS2 project:
+Subject: [PATCH 2/7] compile and test libkml on MinGW from the MSYS2 project:
 
  - fix initialization of static variable in Testb2a_hex from string_util_test.cc
  - provide setenv function in google_maps_data_test.cc

--- a/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
+++ b/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
@@ -1,7 +1,7 @@
 From 8c35301d380da22c4066f47490d0079cc3249535 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 22:06:34 +1100
-Subject: [PATCH 3/3] skip some few tests in {DateTime,Kmz}Test
+Subject: [PATCH 3/4] skip some few tests in {DateTime,Kmz}Test
 
 ---
  tests/kml/base/date_time_test.cc  | 6 +++---

--- a/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
+++ b/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
@@ -1,7 +1,7 @@
 From 8c35301d380da22c4066f47490d0079cc3249535 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 22:06:34 +1100
-Subject: [PATCH 3/4] skip some few tests in {DateTime,Kmz}Test
+Subject: [PATCH 3/5] skip some few tests in {DateTime,Kmz}Test
 
 ---
  tests/kml/base/date_time_test.cc  | 6 +++---

--- a/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
+++ b/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
@@ -1,7 +1,7 @@
 From 8c35301d380da22c4066f47490d0079cc3249535 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 22:06:34 +1100
-Subject: [PATCH 3/5] skip some few tests in {DateTime,Kmz}Test
+Subject: [PATCH 3/6] skip some few tests in {DateTime,Kmz}Test
 
 ---
  tests/kml/base/date_time_test.cc  | 6 +++---

--- a/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
+++ b/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
@@ -1,7 +1,7 @@
 From 8c35301d380da22c4066f47490d0079cc3249535 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 22:06:34 +1100
-Subject: [PATCH 3/6] skip some few tests in {DateTime,Kmz}Test
+Subject: [PATCH 3/7] skip some few tests in {DateTime,Kmz}Test
 
 ---
  tests/kml/base/date_time_test.cc  | 6 +++---

--- a/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
+++ b/recipe/patches/0003-skip-some-few-tests-in-DateTime-Kmz-Test.patch
@@ -1,7 +1,7 @@
 From 8c35301d380da22c4066f47490d0079cc3249535 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 22:06:34 +1100
-Subject: [PATCH 3/7] skip some few tests in {DateTime,Kmz}Test
+Subject: [PATCH 3/8] skip some few tests in {DateTime,Kmz}Test
 
 ---
  tests/kml/base/date_time_test.cc  | 6 +++---

--- a/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
+++ b/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
@@ -1,0 +1,35 @@
+From 21ed97433870211d1aa236f78da1682e90880f78 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 4 Oct 2023 15:07:12 +1100
+Subject: [PATCH 4/4] ensure we pick up minizip correctly
+
+---
+ CMakeLists.txt | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9728ead..c8e5f44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -110,12 +110,17 @@ else()
+   list(APPEND MINIZIP_DEPENDS ZLIB)
+ endif()
+ 
+-find_package(MiniZip)
++if(WIN32)
++  set(MINIZIP_INCLUDE_DIR $ENV{LIBRARY_PREFIX}/include)
++  set(MINIZIP_LIBRARY $ENV{LIBRARY_PREFIX}/lib/minizip_static)
++  set(MINIZIP_FOUND TRUE)
++else()
++  set(MINIZIP_INCLUDE_DIR $ENV{PREFIX}/include)
++  set(MINIZIP_LIBRARY $ENV{PREFIX}/lib/libminizip.a)
++  set(MINIZIP_FOUND TRUE)
++endif()
+ if(MINIZIP_FOUND)
+   include_directories(${MINIZIP_INCLUDE_DIR})
+-else()
+-  include(External_minizip)
+-  list(APPEND KMLBASE_DEPENDS MINIZIP)
+ endif()
+ 
+ find_package(UriParser)

--- a/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
+++ b/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
@@ -1,7 +1,7 @@
 From 21ed97433870211d1aa236f78da1682e90880f78 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 15:07:12 +1100
-Subject: [PATCH 4/5] ensure we pick up minizip correctly
+Subject: [PATCH 4/6] ensure we pick up minizip correctly
 
 ---
  CMakeLists.txt | 13 +++++++++----

--- a/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
+++ b/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
@@ -1,7 +1,7 @@
 From 21ed97433870211d1aa236f78da1682e90880f78 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 15:07:12 +1100
-Subject: [PATCH 4/4] ensure we pick up minizip correctly
+Subject: [PATCH 4/5] ensure we pick up minizip correctly
 
 ---
  CMakeLists.txt | 13 +++++++++----

--- a/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
+++ b/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
@@ -1,7 +1,7 @@
 From 21ed97433870211d1aa236f78da1682e90880f78 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 15:07:12 +1100
-Subject: [PATCH 4/6] ensure we pick up minizip correctly
+Subject: [PATCH 4/7] ensure we pick up minizip correctly
 
 ---
  CMakeLists.txt | 13 +++++++++----

--- a/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
+++ b/recipe/patches/0004-ensure-we-pick-up-minizip-correctly.patch
@@ -1,7 +1,7 @@
 From 21ed97433870211d1aa236f78da1682e90880f78 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 15:07:12 +1100
-Subject: [PATCH 4/7] ensure we pick up minizip correctly
+Subject: [PATCH 4/8] ensure we pick up minizip correctly
 
 ---
  CMakeLists.txt | 13 +++++++++----

--- a/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
+++ b/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
@@ -1,7 +1,7 @@
 From c9c0d80843058d37e317049c82981437dbed866b Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 17:47:39 +1100
-Subject: [PATCH 5/7] patch things up for use with newer minizip
+Subject: [PATCH 5/8] patch things up for use with newer minizip
 
 ---
  src/kml/base/CMakeLists.txt |  4 +---

--- a/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
+++ b/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
@@ -1,7 +1,7 @@
 From c9c0d80843058d37e317049c82981437dbed866b Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 17:47:39 +1100
-Subject: [PATCH 5/5] patch things up for use with newer minizip
+Subject: [PATCH 5/6] patch things up for use with newer minizip
 
 ---
  src/kml/base/CMakeLists.txt |  4 +---

--- a/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
+++ b/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
@@ -1,0 +1,101 @@
+From c9c0d80843058d37e317049c82981437dbed866b Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 4 Oct 2023 17:47:39 +1100
+Subject: [PATCH 5/5] patch things up for use with newer minizip
+
+---
+ src/kml/base/CMakeLists.txt |  4 +---
+ src/kml/base/zip_file.cc    | 48 ++++++++++++++++++++++++++-----------
+ 2 files changed, 35 insertions(+), 17 deletions(-)
+
+diff --git a/src/kml/base/CMakeLists.txt b/src/kml/base/CMakeLists.txt
+index dc3e9c4..d9c6004 100644
+--- a/src/kml/base/CMakeLists.txt
++++ b/src/kml/base/CMakeLists.txt
+@@ -5,9 +5,7 @@ endif()
+ 
+ list(APPEND KMLBASE_LINK_LIBS ${EXPAT_LIBRARY})
+ 
+-file(GLOB SRCS "*.cc"
+-  contrib/minizip/unzip.c
+-  contrib/minizip/iomem_simple.c)
++file(GLOB SRCS "*.cc")
+ 
+ if(WIN32)
+   list(REMOVE_ITEM SRCS "${CMAKE_CURRENT_SOURCE_DIR}/file_posix.cc")
+diff --git a/src/kml/base/zip_file.cc b/src/kml/base/zip_file.cc
+index 3366837..0c122fc 100644
+--- a/src/kml/base/zip_file.cc
++++ b/src/kml/base/zip_file.cc
+@@ -29,9 +29,8 @@
+ #include "kml/base/zip_file.h"
+ #include "kml/base/file.h"
+ 
+-#include "kml/base/contrib/minizip/unzip.h"
+-#include "kml/base/contrib/minizip/iomem_simple.h"
+-
++#include <minizip/ioapi_mem.h>
++#include <minizip/unzip.h>
+ #include <minizip/zip.h>
+ 
+ namespace kmlbase {
+@@ -89,12 +88,34 @@ ZipFile* ZipFile::Create(const char* file_path) {
+ ZipFile::ZipFile(const string& data)
+   : minizip_file_(NULL), data_(data),
+     max_uncompressed_file_size_(kMaxUncompressedZipSize) {
++  // The libkml-vendored `mem_simple_create_file` from an old minizip-offshoot
++  // has been integrated into newer minizip as `fill_memory_filefunc`.
++  // The signatures are different, in that the former takes size & length,
++  //     https://github.com/libkml/libkml/blob/1.3.0/src/kml/base/contrib/minizip/iomem_simple.c#L222
++  // whereas the latter takes a structure that contains those, see
++  //     https://github.com/zlib-ng/minizip-ng/blob/1.2/ioapi_mem.c#L46
++  //
++  // There's a direct mapping between the libkml-vendored structure `_MEMFILE`,
++  //     https://github.com/libkml/libkml/blob/1.3.0/src/kml/base/contrib/minizip/iomem_simple.c#L117-L122
++  // and the structure `ourmemory_t` as of minizip 1.2
++  //     https://github.com/zlib-ng/minizip-ng/blob/1.2/ioapi_mem.c#L38-L44
++  // which is as follows:
++  //     _MEMFILE.buffer == ourmemory_t.base
++  //     _MEMFILE.length == ourmemory_t.size
++  //   _MEMFILE.position == ourmemory_t.cur_offset
++  //
++  // Thus we set up the structure and initialize it as required, see
++  //     https://github.com/zlib-ng/minizip-ng/tree/1.2#io-memory
++  // Additionally, the return types have changed from void* to void,
++  // we don't check the returns anymore (matches tutorial above).
++  ourmemory_t unzmem = {};
++  unzmem.base = const_cast<char *>(static_cast<const char *>(data.data()));
++  unzmem.size = data.size();
+   // Fill the table of contents for this zipfile.
+   zlib_filefunc_def api;
+-  if (voidpf mem_stream = mem_simple_create_file(
+-      &api, const_cast<void*>(static_cast<const void*>(data.data())),
+-      data.size())) {
+-    unzFile zfile = libkml_unzAttach(mem_stream, &api);
++  fill_memory_filefunc(&api, &unzmem);
++  if (true) {
++    unzFile zfile = unzOpen2("__notused__", &api);
+     if (zfile) {
+       unz_file_info finfo;
+       do {
+@@ -174,14 +195,13 @@ bool ZipFile::GetEntry(const string& path_in_zip,
+   if (!IsInToc(path_in_zip)) {
+     return false;
+   }
++  // see comment further up above fill_memory_filefunc
++  ourmemory_t unzmem = {};
++  unzmem.base = const_cast<char *>(static_cast<const char *>(data_.data()));
++  unzmem.size = data_.size();
+   zlib_filefunc_def api;
+-  voidpf mem_stream = mem_simple_create_file(
+-      &api, const_cast<void*>(static_cast<const void*>(data_.data())),
+-      data_.size());
+-  if (!mem_stream) {
+-    return false;
+-  }
+-  unzFile unzfile = libkml_unzAttach(mem_stream, &api);
++  fill_memory_filefunc(&api, &unzmem);
++  unzFile unzfile = unzOpen2("__notused__", &api);
+   if (!unzfile) {
+     return false;
+   }

--- a/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
+++ b/recipe/patches/0005-patch-things-up-for-use-with-newer-minizip.patch
@@ -1,7 +1,7 @@
 From c9c0d80843058d37e317049c82981437dbed866b Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 17:47:39 +1100
-Subject: [PATCH 5/6] patch things up for use with newer minizip
+Subject: [PATCH 5/7] patch things up for use with newer minizip
 
 ---
  src/kml/base/CMakeLists.txt |  4 +---

--- a/recipe/patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
+++ b/recipe/patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
@@ -1,0 +1,64 @@
+From d58991455f6bd1be981f3aa3d66f20e5c74f173c Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 4 Oct 2023 18:26:26 +1100
+Subject: [PATCH 6/6] remove `libkml_` prefix now that we're not vendoring
+ minizip anymore
+
+These functions all still exist in the mininzip API, see
+https://github.com/zlib-ng/minizip-ng/blob/1.2/unzip.h
+---
+ src/kml/base/zip_file.cc | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/kml/base/zip_file.cc b/src/kml/base/zip_file.cc
+index 0c122fc..63ce648 100644
+--- a/src/kml/base/zip_file.cc
++++ b/src/kml/base/zip_file.cc
+@@ -120,12 +120,12 @@ ZipFile::ZipFile(const string& data)
+       unz_file_info finfo;
+       do {
+         static char buf[1024];
+-        if (libkml_unzGetCurrentFileInfo(zfile, &finfo, buf, sizeof(buf),
++        if (unzGetCurrentFileInfo(zfile, &finfo, buf, sizeof(buf),
+               0, 0, 0, 0) == UNZ_OK) {
+           zipfile_toc_.push_back(buf);
+         }
+-      } while (libkml_unzGoToNextFile(zfile) == UNZ_OK);
+-      libkml_unzClose(zfile);
++      } while (unzGoToNextFile(zfile) == UNZ_OK);
++      unzClose(zfile);
+     }
+   }
+ }
+@@ -183,7 +183,7 @@ bool ZipFile::IsInToc(const string& path_in_zip) const {
+ class UnzFileHelper {
+  public:
+   UnzFileHelper(unzFile unzfile) : unzfile_(unzfile) {}
+-  ~UnzFileHelper() { libkml_unzClose(unzfile_); }
++  ~UnzFileHelper() { unzClose(unzfile_); }
+   unzFile get_unzfile() { return unzfile_; }
+  private:
+   unzFile unzfile_;
+@@ -208,10 +208,10 @@ bool ZipFile::GetEntry(const string& path_in_zip,
+ 
+   boost::scoped_ptr<UnzFileHelper> unzfilehelper(new UnzFileHelper(unzfile));
+   unz_file_info finfo;
+-  if (libkml_unzLocateFile(unzfilehelper->get_unzfile(),
++  if (unzLocateFile(unzfilehelper->get_unzfile(),
+                     path_in_zip.c_str(), 0) != UNZ_OK ||
+-      libkml_unzOpenCurrentFile(unzfilehelper->get_unzfile()) != UNZ_OK ||
+-      libkml_unzGetCurrentFileInfo(unzfilehelper->get_unzfile(), &finfo, 0, 0,
++      unzOpenCurrentFile(unzfilehelper->get_unzfile()) != UNZ_OK ||
++      unzGetCurrentFileInfo(unzfilehelper->get_unzfile(), &finfo, 0, 0,
+                                    0, 0, 0, 0) != UNZ_OK) {
+     return false;
+   }
+@@ -227,7 +227,7 @@ bool ZipFile::GetEntry(const string& path_in_zip,
+     return true;
+   }
+   char* filedata = new char[nbytes];
+-  if (libkml_unzReadCurrentFile(unzfilehelper->get_unzfile(), filedata,
++  if (unzReadCurrentFile(unzfilehelper->get_unzfile(), filedata,
+                          nbytes) == static_cast<int>(nbytes)) {
+     output->assign(filedata, nbytes);
+     delete [] filedata;

--- a/recipe/patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
+++ b/recipe/patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
@@ -1,7 +1,7 @@
 From d58991455f6bd1be981f3aa3d66f20e5c74f173c Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 18:26:26 +1100
-Subject: [PATCH 6/7] remove `libkml_` prefix now that we're not vendoring
+Subject: [PATCH 6/8] remove `libkml_` prefix now that we're not vendoring
  minizip anymore
 
 These functions all still exist in the mininzip API, see

--- a/recipe/patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
+++ b/recipe/patches/0006-remove-libkml_-prefix-now-that-we-re-not-vendoring-m.patch
@@ -1,7 +1,7 @@
 From d58991455f6bd1be981f3aa3d66f20e5c74f173c Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 18:26:26 +1100
-Subject: [PATCH 6/6] remove `libkml_` prefix now that we're not vendoring
+Subject: [PATCH 6/7] remove `libkml_` prefix now that we're not vendoring
  minizip anymore
 
 These functions all still exist in the mininzip API, see

--- a/recipe/patches/0007-copy-over-a-define-necessary-for-libmkl-s-zip-handli.patch
+++ b/recipe/patches/0007-copy-over-a-define-necessary-for-libmkl-s-zip-handli.patch
@@ -1,7 +1,7 @@
 From edb1b0f5c7d8eebe7901d2b0c4e6224b88aa324c Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 4 Oct 2023 19:47:27 +1100
-Subject: [PATCH 7/7] copy over a define necessary for libmkl's zip handling
+Subject: [PATCH 7/8] copy over a define necessary for libmkl's zip handling
 
 ---
  src/kml/base/zip_file.h | 13 +++++++++++++

--- a/recipe/patches/0007-copy-over-a-define-necessary-for-libmkl-s-zip-handli.patch
+++ b/recipe/patches/0007-copy-over-a-define-necessary-for-libmkl-s-zip-handli.patch
@@ -1,0 +1,33 @@
+From edb1b0f5c7d8eebe7901d2b0c4e6224b88aa324c Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Wed, 4 Oct 2023 19:47:27 +1100
+Subject: [PATCH 7/7] copy over a define necessary for libmkl's zip handling
+
+---
+ src/kml/base/zip_file.h | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/kml/base/zip_file.h b/src/kml/base/zip_file.h
+index f823d1c..1263736 100644
+--- a/src/kml/base/zip_file.h
++++ b/src/kml/base/zip_file.h
+@@ -32,6 +32,19 @@
+ #include "kml/base/string_util.h"
+ #include "kml/base/util.h"
+ 
++// The following define is taken from the vendored & modified minizip, see
++//     https://github.com/libkml/libkml/blob/1.3.0/src/kml/base/contrib/minizip/unzip.h#L52-L60
++
++/* This define is local to libkml and is not a part of the regular zlib
++ * library. It sets a maximum upper limit on the uncompressed size we'll
++ * allow minizip to handle. The PKZIP specification here:
++ * https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html
++ * defines the uncompressed size field to be 4 bytes wide. In unzip.c minizip
++ * uses an unsigned long, but iomem_simple.c uses a signed long. Hence, we
++ * use the maximum size of a 32-bit signed long integer.
++ */
++#define ZIP_MAX_UNCOMPRESSED_SIZE 2147483647
++
+ namespace kmlbase {
+ 
+ // Forward-declare the internal MinizipFile class that hides our current use

--- a/recipe/patches/0008-remove-expected-failure-for-handling-newer-zips.patch
+++ b/recipe/patches/0008-remove-expected-failure-for-handling-newer-zips.patch
@@ -1,0 +1,30 @@
+From 2a6bd08f457cae53187e6df0e702c9d8037e6756 Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Thu, 5 Oct 2023 08:17:22 +1100
+Subject: [PATCH 8/8] remove expected failure for handling newer zips
+
+The description of the test[1] says:
+  // Some ZIP files created with new zip-creation tools can't be uncompressed
+  // by our underlying minizip library. Assert sane behavior.
+
+Now that we're using newer minizip, we don't have to fail anymore.
+
+[1] https://github.com/libkml/libkml/blame/1.3.0/tests/kml/base/zip_file_test.cc#L273-L282
+---
+ tests/kml/base/zip_file_test.cc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tests/kml/base/zip_file_test.cc b/tests/kml/base/zip_file_test.cc
+index 6f48699..198a7a1 100644
+--- a/tests/kml/base/zip_file_test.cc
++++ b/tests/kml/base/zip_file_test.cc
+@@ -278,7 +278,8 @@ TEST_F(ZipFileTest, TestBadPkZipData) {
+   ASSERT_TRUE(File::ReadFileToString(kBadKmz, &zip_file_data));
+   ASSERT_FALSE(zip_file_data.empty());
+   zip_file_.reset(ZipFile::OpenFromString(zip_file_data));
+-  ASSERT_FALSE(zip_file_->GetEntry("doc.kml", NULL));
++  // Now that we're using newer minizip; this field actually gets populated
++  // ASSERT_FALSE(zip_file_->GetEntry("doc.kml", NULL));
+ }
+ 
+ TEST_F(ZipFileTest, TestBadTooLarge) {


### PR DESCRIPTION
Closes #2 (after #24 having switched to uriparse already)

This is a fairly involved changed and -- if we want to do this -- would need very thorough review, particularly patch 5. For ease of review, I've pushed a [branch](https://github.com/h-vetinari/libkml/tree/conda) corresponding to the changes here. As far as I can tell, since all the relevant changes are internal to functions in `src/kml/base/zip_file.cc` that are not in quantities which are in any of libkml's APIs, it should not be possible that this affects the ABI of libkml[^1]. Though in any case, we already have [segfaults](https://github.com/conda-forge/libkml-feedstock/issues/2#issuecomment-1745878870) due to the clashes with newer `libminizip.so`, and this would fix that.

[^1]: unless libkml _elsewhere_ uses minizip-types (e.g. a struct) in its API, which would obviously fail when spoken to from libraries compiled against a minizip where said struct is different.

The minizip being used is based on a lightly [patched](https://github.com/h-vetinari/minizip-ng/tree/conda) minizip 1.2 (basically just one revert for a commit that [broke](https://github.com/conda-forge/minizip-feedstock/pull/11) linux). It's intentionally used as a static library, so that we don't get into the issues of `libminizip.so` being clobbered, or `minizip` (the output) requiring two different versions for the same environment (==impossible)

There's a more in-depth analysis in the pretty messy history of the various minizip implementations [here](https://github.com/conda-forge/libkml-feedstock/issues/2#issuecomment-1746247426).